### PR TITLE
fix: added code to create suggestions for an array when no hypen

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -151,6 +151,20 @@ export class YamlCompletion {
         this.indentation + arrayIndentCompensation
       );
     }
+
+    // if no suggestions and if on an empty line then try as an array
+    if (result.items.length === 0 && lineContent.match(/^\s*$/)) {
+      const modificationForInvoke = '-';
+      const newPosition = Position.create(position.line, position.character + 1);
+      result = await this.doCompletionWithModification(
+        result,
+        document,
+        position,
+        isKubernetes,
+        newPosition,
+        modificationForInvoke
+      );
+    }
     this.processInlineInitialization(result, lineContent);
 
     // const secs = (Date.now() - startTime) / 1000;

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -497,4 +497,33 @@ describe('Auto Completion Tests Extended', () => {
       assert.equal(completion.items.length, 0);
     });
   });
+
+  describe('completion of array', () => {
+    it('should suggest when no hypen (-)', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          actions: {
+            type: 'array',
+            items: {
+              type: 'array',
+              items: {
+                type: 'string',
+                defaultSnippets: [
+                  {
+                    label: 'My array item',
+                    body: { item1: '$1' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'actions:\n  ';
+      const completion = await parseSetup(content, content.length);
+      assert.equal(completion.items.length, 1);
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
```yaml
example:
  #cursor here
```
will auto-complete to:
```yaml
example:
  - array:
      item: "item"
```

### What issues does this PR fix or reference?
https://github.com/jigx-com/jigx-builder/issues/520

### Is it tested? How?
Manual testing and unit test added
