### PR TITLE
fix: autocomplete indent on object within an array

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1299,7 +1299,7 @@ export class YamlCompletion {
               if (arrayInsertLines.length > 1) {
                 for (let index = 1; index < arrayInsertLines.length; index++) {
                   const element = arrayInsertLines[index];
-                  arrayInsertLines[index] = `${indent}${this.indentation}  ${element.trimLeft()}`;
+                  arrayInsertLines[index] = `  ${element}`;
                 }
                 arrayTemplate = arrayInsertLines.join('\n');
               }

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -402,6 +402,54 @@ objB:
       })
     );
   });
+  it('Autocomplete indent on array object when parent is array of an array', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        array1: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['thing1'],
+            properties: {
+              thing1: {
+                type: 'object',
+                required: ['array2'],
+                properties: {
+                  array2: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      required: ['thing2', 'type'],
+                      properties: {
+                        type: {
+                          type: 'string',
+                        },
+                        thing2: {
+                          type: 'object',
+                          required: ['item1', 'item2'],
+                          properties: {
+                            item1: { type: 'string' },
+                            item2: { type: 'string' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const content = 'array1:\n  - ';
+    const completion = await parseSetup(content, 1, 4);
+
+    expect(completion.items[0].insertText).to.be.equal(
+      'thing1:\n    array2:\n      - type: $1\n        thing2:\n          item1: $2\n          item2: $3'
+    );
+  });
   describe('array indent on different index position', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the indent is incorrect for an object within an array that is also within an array.

Given the following schema:
```json
{
  "type": "object",
  "properties": {
    "array1": {
      "type": "array",
      "items": {
        "type": "object",
        "required": ["thing1"],
        "properties": {
          "thing1": {
            "type": "object",
            "required": ["array2"],
            "properties": {
              "array2": {
                "type": "array",
                "items": {
                  "type": "object",
                  "required": ["thing2", "type"],
                  "properties": {
                    "type": {
                      "type": "string"
                    },
                    "thing2": {
                      "type": "object",
                      "required": ["item1", "item2"],
                      "properties": {
                        "item1": { "type": "string" },
                        "item2": { "type": "string" }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```

When autocomplete is attempted on:
```yaml
array1:
  - #cursor here
 ```
It previously autocompleted to:
```yaml
array1:
  - thing1:
      array2:
        - type: 
          thing2:
          item1: 
          item2: 
```
After the fix it correctly indents as:
```yaml
array1:
  - thing1:
      array2:
        - type: 
          thing2:
            item1: 
            item2: 
```

The prior code that added indentation should now be handled by this fix: https://github.com/redhat-developer/yaml-language-server/pull/634
 

### What issues does this PR fix or reference?
https://app.zenhub.com/workspaces/eusa-standup-board---6071eb7d59410e000e9bc963/issues/jigx-com/jigx-builder/307

### Is it tested? How?
Manual testing and unit test.
