### PR TITLE
fix: default snippet in array

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1084,7 +1084,7 @@ export class YamlCompletion {
                   insertTextFormat: InsertTextFormat.Snippet,
                 });
 
-                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
+                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types, true);
               } else if (typeof s.schema.items === 'object' && s.schema.items.anyOf) {
                 s.schema.items.anyOf
                   .filter((i) => typeof i === 'object')
@@ -1106,7 +1106,7 @@ export class YamlCompletion {
                       insertTextFormat: InsertTextFormat.Snippet,
                     });
                   });
-                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
+                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types, true);
               } else {
                 this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
               }
@@ -1472,21 +1472,21 @@ export class YamlCompletion {
   ): void {
     if (typeof schema === 'object') {
       this.addEnumValueCompletions(schema, separatorAfter, collector, isArray);
-      this.addDefaultValueCompletions(schema, separatorAfter, collector);
+      this.addDefaultValueCompletions(schema, separatorAfter, collector, 0, isArray);
       this.collectTypes(schema, types);
       if (Array.isArray(schema.allOf)) {
         schema.allOf.forEach((s) => {
-          return this.addSchemaValueCompletions(s, separatorAfter, collector, types);
+          return this.addSchemaValueCompletions(s, separatorAfter, collector, types, isArray);
         });
       }
       if (Array.isArray(schema.anyOf)) {
         schema.anyOf.forEach((s) => {
-          return this.addSchemaValueCompletions(s, separatorAfter, collector, types);
+          return this.addSchemaValueCompletions(s, separatorAfter, collector, types, isArray);
         });
       }
       if (Array.isArray(schema.oneOf)) {
         schema.oneOf.forEach((s) => {
-          return this.addSchemaValueCompletions(s, separatorAfter, collector, types);
+          return this.addSchemaValueCompletions(s, separatorAfter, collector, types, isArray);
         });
       }
     }
@@ -1510,7 +1510,8 @@ export class YamlCompletion {
     schema: JSONSchema,
     separatorAfter: string,
     collector: CompletionsCollector,
-    arrayDepth = 0
+    arrayDepth = 0,
+    isArray?: boolean
   ): void {
     let hasProposals = false;
     if (isDefined(schema.default)) {
@@ -1552,11 +1553,21 @@ export class YamlCompletion {
         hasProposals = true;
       });
     }
-    this.collectDefaultSnippets(schema, separatorAfter, collector, {
+
+    let stringifySettings = {
       newLineFirst: true,
       indentFirstObject: true,
       shouldIndentWithTab: true,
-    });
+    };
+
+    if (isArray) {
+      stringifySettings = {
+        newLineFirst: false,
+        indentFirstObject: false,
+        shouldIndentWithTab: false,
+      };
+    }
+    this.collectDefaultSnippets(schema, separatorAfter, collector, stringifySettings, 0, isArray);
     if (!hasProposals && typeof schema.items === 'object' && !Array.isArray(schema.items)) {
       this.addDefaultValueCompletions(schema.items, separatorAfter, collector, arrayDepth + 1);
     }
@@ -1612,7 +1623,8 @@ export class YamlCompletion {
     separatorAfter: string,
     collector: CompletionsCollector,
     settings: StringifySettings,
-    arrayDepth = 0
+    arrayDepth = 0,
+    isArray?: boolean
   ): void {
     if (Array.isArray(schema.defaultSnippets)) {
       for (const s of schema.defaultSnippets) {
@@ -1623,7 +1635,7 @@ export class YamlCompletion {
         let filterText: string;
         if (isDefined(value)) {
           const type = s.type || schema.type;
-          if (arrayDepth === 0 && type === 'array') {
+          if ((arrayDepth === 0 && type === 'array') || isArray) {
             // We know that a - isn't present yet so we need to add one
             const fixedObj = {};
             Object.keys(value).forEach((val, index) => {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1554,20 +1554,18 @@ export class YamlCompletion {
       });
     }
 
-    let stringifySettings = {
-      newLineFirst: true,
-      indentFirstObject: true,
-      shouldIndentWithTab: true,
-    };
-
-    if (isArray) {
-      stringifySettings = {
-        newLineFirst: false,
-        indentFirstObject: false,
-        shouldIndentWithTab: false,
-      };
-    }
-    this.collectDefaultSnippets(schema, separatorAfter, collector, stringifySettings, 0, isArray);
+    this.collectDefaultSnippets(
+      schema,
+      separatorAfter,
+      collector,
+      {
+        newLineFirst: !isArray,
+        indentFirstObject: !isArray,
+        shouldIndentWithTab: !isArray,
+      },
+      0,
+      isArray
+    );
     if (!hasProposals && typeof schema.items === 'object' && !Array.isArray(schema.items)) {
       this.addDefaultValueCompletions(schema.items, separatorAfter, collector, arrayDepth + 1);
     }
@@ -1624,7 +1622,7 @@ export class YamlCompletion {
     collector: CompletionsCollector,
     settings: StringifySettings,
     arrayDepth = 0,
-    isArray?: boolean
+    isArray = false
   ): void {
     if (Array.isArray(schema.defaultSnippets)) {
       for (const s of schema.defaultSnippets) {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -450,6 +450,39 @@ objB:
       'thing1:\n    array2:\n      - type: $1\n        thing2:\n          item1: $2\n          item2: $3'
     );
   });
+  it('Autocomplete with snippet without hypen (-) inside an array', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        array1: {
+          type: 'array',
+          items: {
+            type: 'object',
+            defaultSnippets: [
+              {
+                label: 'My array item',
+                body: { item1: '$1' },
+              },
+            ],
+            required: ['thing1'],
+            properties: {
+              thing1: {
+                type: 'object',
+                required: ['item1'],
+                properties: {
+                  item1: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const content = 'array1:\n  - thing1:\n    item1: $1\n  | |';
+    const completion = await parseCaret(content);
+
+    expect(completion.items[1].insertText).to.be.equal('- item1: ');
+  });
   describe('array indent on different index position', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where default snippets where not being entered correctly within an array.

Given the following schema:
```json
{
  "type": "object",
  "properties": {
    "array1": {
      "type": "array",
      "items": {
        "type": "object",
        "defaultSnippets": [
          {
            "label": "My array item",
            "body": { "item1": "$1" }
          }
        ],
        "required": ["thing1"],
        "properties": {
          "thing1": {
            "type": "object",
            "required": ["item1"],
            "properties": {
              "item1": { "type": "string" }
            }
          }
        }
      }
    }
  }
}
```

When autocomplete is attempted on:
```yaml
array1:
  - thing1:
      item1: aa
  #cursor here
 ```
It previously autocompleted to:
```yaml
array1:
  - thing1:
      item1: aa

      item1:
```
After the fix it correctly indents as:
```yaml
array1:
  - thing1:
      item1: aa
  - item1: 
```

### What issues does this PR fix or reference?
https://github.com/jigx-com/jigx-builder/issues/499

PR on redhat: https://github.com/redhat-developer/yaml-language-server/pull/755

### Is it tested? How?
Manual testing and unit test.
