### PR TITLE
Fix:ctx inside the expression

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -44,6 +44,7 @@ const doubleQuotesEscapeRegExp = /[\\]+"/g;
 
 const ctxSymbolLabel = '=@ctx';
 const ctxSymbol = '@ctx';
+const ctxSymbolPrefix = '@';
 
 const parentCompletionKind = CompletionItemKind.Class;
 
@@ -118,9 +119,9 @@ export class YamlCompletion {
       ctxSymbol &&
       lineContent
         .substring(0, position.character) // take lineContent only to cursor position
-        .match(new RegExp(`(${ctxSymbol})(?!.*\\1).*$`)); // https://regex101.com/r/2ewq5g/2 takes last occurrence of the ctx to the end
+        .match(new RegExp(`=?(${ctxSymbolPrefix})(?!.*\\1).*$`)); // https://regex101.com/r/2ewq5g takes last occurrence of the ctx to the end
     if (lineCtx) {
-      result = await this.doInlineCompletion(document, position, '=' + lineCtx[0]);
+      result = await this.doInlineCompletion(document, position, lineCtx[0]);
       return result;
     }
     // auto add space after : if needed
@@ -228,6 +229,10 @@ export class YamlCompletion {
   }
 
   private async doInlineCompletion(document: TextDocument, position: Position, lineCtx: string): Promise<CompletionList> {
+    const hasEqualSymbol = lineCtx.startsWith('=');
+    if (!hasEqualSymbol) {
+      lineCtx = '=' + lineCtx;
+    }
     const props = lineCtx.split('.');
     let newText = props.reduce((reducer, prop, index) => {
       if (!prop || prop === '\n') {
@@ -255,13 +260,24 @@ export class YamlCompletion {
 
     resultLocal.items.forEach((inlineItem) => {
       let inlineText = inlineItem.insertText;
+
+      // when expression doesn't have `=`, remove it also from `=@ctx` result
+      if (!hasEqualSymbol && inlineItem.label === ctxSymbolLabel) {
+        inlineItem.label = ctxSymbol;
+        inlineText = ctxSymbol;
+      }
+
       inlineText = inlineText.replace(/:\n?\s*(\$1)?/g, '.').replace(/\.$/, '');
       inlineItem.insertText = inlineText;
       if (inlineItem.textEdit) {
         inlineItem.textEdit.newText = inlineText;
         if (TextEdit.is(inlineItem.textEdit)) {
           const diff = inlineItem.textEdit.range.end.character - inlineItem.textEdit.range.start.character; // support =@ctx.da
-          inlineItem.textEdit.range = Range.create(Position.create(position.line, position.character - diff), position);
+          const equalSymbolCompensation = hasEqualSymbol ? 0 : 1;
+          inlineItem.textEdit.range = Range.create(
+            Position.create(position.line, position.character - diff + equalSymbolCompensation),
+            position
+          );
         }
       }
       inlineItem.commitCharacters = ['.'];

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -121,6 +121,16 @@ export class YamlCompletion {
         .substring(0, position.character) // take lineContent only to cursor position
         .match(new RegExp(`=?(${ctxSymbolPrefix})(?!.*\\1).*$`)); // https://regex101.com/r/2ewq5g takes last occurrence of the ctx to the end
     if (lineCtx) {
+      const hasEqualSymbol = lineCtx[0].startsWith('=');
+      const lineContentBeforeCtx = lineContent.slice(0, lineCtx.index);
+      // don't allow @ctx on the beginning of the expression
+      if (!hasEqualSymbol && /:[ \t'"|>]*$/.test(lineContentBeforeCtx)) {
+        return result;
+      }
+      // don't allow =@ctx inside jsonata,
+      if (hasEqualSymbol && lineContentBeforeCtx.includes(ctxSymbolLabel)) {
+        return result;
+      }
       result = await this.doInlineCompletion(document, position, lineCtx[0]);
       return result;
     }

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -225,28 +225,35 @@ describe('Auto Completion Tests Extended', () => {
     });
 
     describe('Inner ctx inside expression', () => {
-      it('ctx inside apostrophes', async () => {
+      it('=@ctx inside apostrophes', async () => {
         languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
         const content = 'value: "=@ctx."';
         const result = await parseSetup(content, content.length - 1);
         assert.strictEqual(result.items.length, 2);
         assert.strictEqual(result.items[0].insertText, 'user');
       });
-      it('ctx with comment', async () => {
+      it('=@ctx within comment', async () => {
         languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
         const content = 'value: =@ctx. #comment';
         const result = await parseSetup(content, 'value: =@ctx.'.length);
         assert.strictEqual(result.items.length, 2);
         assert.strictEqual(result.items[0].insertText, 'user');
       });
-      it('ctx with jsonata expression', async () => {
+      it('@ctx within jsonata expression', async () => {
         languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
         const content = 'value: =@ctx.test1+@ctx.da';
         const result = await parseSetup(content, content.length);
         assert.strictEqual(result.items.length, 2);
         assert.strictEqual(result.items[1].insertText, 'data');
       });
-      it('ctx with predicate', async () => {
+      it('@ct within jsonata expression', async () => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'value: =@ctx.test1+@ct';
+        const result = await parseSetup(content, content.length);
+        assert.strictEqual(result.items.length, 1);
+        assert.strictEqual(result.items[0].insertText, '@ctx');
+      });
+      it('@ctx within predicate', async () => {
         languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
         const content = 'value: =@ctx.test1+@ctx[type=3].';
         const result = await parseSetup(content, content.length);

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -260,6 +260,18 @@ describe('Auto Completion Tests Extended', () => {
         assert.strictEqual(result.items.length, 2);
         assert.strictEqual(result.items[1].insertText, 'data');
       });
+      it('do not allow @ctx on the beginning of the expression', async () => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'value: @ct';
+        const result = await parseSetup(content, content.length);
+        assert.strictEqual(result.items.length, 0);
+      });
+      it('do not allow =@ctx inside jsonata', async () => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'value: =@ctx.test1+=@ct';
+        const result = await parseSetup(content, content.length);
+        assert.strictEqual(result.items.length, 0);
+      });
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
fix situation where intellisense was failing when attempting to add @ctx within a jsonata expression
this PR is replacement for https://github.com/jigx-com/rh-yaml-language-server/pull/1
and https://github.com/jigx-com/jigx-builder/pull/470

### What issues does this PR fix or reference?
https://github.com/jigx-com/jigx-builder/issues/354

### Is it tested? How?
added UT
