### PR TITLE
Fixed issue where there were trailing spaces after the cursor on a li…

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -391,7 +391,8 @@ export class YamlCompletion {
     if (areOnlySpacesAfterPosition) {
       overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
       const isOnlyWhitespace = lineContent.trim().length === 0;
-      if (node && isScalar(node) && !isOnlyWhitespace) {
+      const isOnlyDash = lineContent.match(/^\s*(-)\s*$/);
+      if (node && isScalar(node) && !isOnlyWhitespace && !isOnlyDash) {
         // line contains part of a key with trailing spaces, adjust the overwrite range to include only the text
         const matches = lineContent.match(/^([\s-]*)[^:]+[ \t]+\n?$/);
         if (matches?.length) {

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -470,6 +470,35 @@ describe('Auto Completion Tests Extended', () => {
           })
         );
       });
+      it('array completion - should suggest correct indent when extra spaces after cursor', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            test: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  objA: {
+                    type: 'object',
+                    required: ['itemA'],
+                    properties: {
+                      itemA: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+        const content = 'test:\n  -               ';
+        const result = await parseSetup(content, 10);
+
+        expect(result.items.length).to.be.equal(1);
+        expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
+      });
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Fixes an indentation issue when you have trailing spaces after the hyphen.

Example:
```yaml
array1:
  - #_______ (# = cursor, _ = spaces)
```

### What issues does this PR fix or reference?
https://github.com/jigx-com/jigx-builder/issues/539

### Is it tested? How?
Manual and unti test.