### PR TITLE
feat: remove img from mardown description

### DIFF
--- a/src/languageservice/services/yamlHoverDetail.ts
+++ b/src/languageservice/services/yamlHoverDetail.ts
@@ -241,7 +241,11 @@ export class YamlHoverDetail {
           results = [''];
         }
 
-        return createHover(results.join('\n\n'), resSchemas, decycleNode);
+        let content = results.join('\n\n');
+
+        content = descriptionImageCleanUp(content);
+
+        return createHover(content, resSchemas, decycleNode);
       }
       return null;
     });
@@ -313,4 +317,8 @@ function toMarkdownCodeBlock(content: string): string {
     return '`` ' + content + ' ``';
   }
   return content;
+}
+
+function descriptionImageCleanUp(markdownString: string): string {
+  return markdownString.replace(/<img[^>]+>/gm, (img) => (img.includes('enableInHover') ? img : ''));
 }

--- a/test/hoverDetail.test.ts
+++ b/test/hoverDetail.test.ts
@@ -141,4 +141,36 @@ Source: [default_schema_id.yaml](file:///default_schema_id.yaml)`
       `A script to run after install\n\nSource: [schema.json](dynamic-schema://schema.json)`
     );
   });
+  describe('Images', async () => {
+    it('Image should be excluded', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          scripts: {
+            type: 'object',
+            markdownDescription: 'First img <img src=... />\nSecond image <img src="2"/>',
+          },
+        },
+      });
+      const content = 'scripts:\n  ';
+      const result = await parseSetup(content, 1, SCHEMA_ID);
+
+      assert.strictEqual((result.contents as MarkupContent).value.includes('<img'), false);
+    });
+    it('Image should be included', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          scripts: {
+            type: 'object',
+            markdownDescription: 'First img <img src=... />\nSecond image <img enableInHover src="2"/>',
+          },
+        },
+      });
+      const content = 'scripts:\n  ';
+      const result = await parseSetup(content, 1, SCHEMA_ID);
+
+      assert.strictEqual((result.contents as MarkupContent).value.includes('<img'), true);
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Exclude all images from the hover schema documentation.
This default functionality can be overridden by the `enableInHover` attribute inside the `<img />` tag.

### What issues does this PR fix or reference?
https://app.clickup.com/t/3w3aant

### Is it tested? How?
added UTs