### PR TITLE
fix: equal ctx compensation

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -271,11 +271,13 @@ export class YamlCompletion {
 
     resultLocal.items.forEach((inlineItem) => {
       let inlineText = inlineItem.insertText;
+      let equalSymbolCompensation = 0;
 
       // when expression doesn't have `=`, remove it also from `=@ctx` result
       if (!hasEqualSymbol && inlineItem.label === ctxSymbolLabel) {
         inlineItem.label = ctxSymbol;
         inlineText = ctxSymbol;
+        equalSymbolCompensation = 1;
       }
 
       inlineText = inlineText.replace(/:\n?\s*(\$1)?/g, '.').replace(/\.$/, '');
@@ -284,7 +286,6 @@ export class YamlCompletion {
         inlineItem.textEdit.newText = inlineText;
         if (TextEdit.is(inlineItem.textEdit)) {
           const diff = inlineItem.textEdit.range.end.character - inlineItem.textEdit.range.start.character; // support =@ctx.da
-          const equalSymbolCompensation = hasEqualSymbol ? 0 : 1;
           inlineItem.textEdit.range = Range.create(
             Position.create(position.line, position.character - diff + equalSymbolCompensation),
             position

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -245,6 +245,9 @@ describe('Auto Completion Tests Extended', () => {
         const result = await parseSetup(content, content.length);
         assert.strictEqual(result.items.length, 2);
         assert.strictEqual(result.items[1].insertText, 'data');
+        const range = (result.items[1].textEdit as TextEdit).range;
+        assert.strictEqual(range.start.character, 24);
+        assert.strictEqual(range.end.character, content.length);
       });
       it('@ct within jsonata expression', async () => {
         languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
@@ -252,6 +255,9 @@ describe('Auto Completion Tests Extended', () => {
         const result = await parseSetup(content, content.length);
         assert.strictEqual(result.items.length, 1);
         assert.strictEqual(result.items[0].insertText, '@ctx');
+        const range = (result.items[0].textEdit as TextEdit).range;
+        assert.strictEqual(range.start.character, 19);
+        assert.strictEqual(range.end.character, content.length);
       });
       it('@ctx within predicate', async () => {
         languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
@@ -271,6 +277,15 @@ describe('Auto Completion Tests Extended', () => {
         const content = 'value: =@ctx.test1+=@ct';
         const result = await parseSetup(content, content.length);
         assert.strictEqual(result.items.length, 0);
+      });
+      it('should replace correct position inside jsonata', async () => {
+        languageService.addSchema(SCHEMA_ID, inlineObjectSchema);
+        const content = 'value: "=$str(@ctx.)"';
+        const result = await parseSetup(content, 19);
+        assert.strictEqual(result.items.length > 0, true);
+        const range = (result.items[0].textEdit as TextEdit).range;
+        assert.strictEqual(range.start.character, 19);
+        assert.strictEqual(range.end.character, 19);
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?
AutoComplete replaces characters - it removes trailing quotation marks "" and brackets () in nested expression
The problem was after `@ctx.anything` without the array symbol


### What issues does this PR fix or reference?
https://app.clickup.com/t/3yacrv7

### Is it tested? How?
added test for positions of the results
