### PR TITLE
fix:schema description section newLine tab replacement

### DIFF
--- a/src/languageservice/utils/jigx/schema2md.ts
+++ b/src/languageservice/utils/jigx/schema2md.ts
@@ -95,7 +95,7 @@ export class Schema2Md {
     const schemaDescription = schema.markdownDescription || schema.description;
     // root description is added in yamlHover service, so skip it here inside the section
     if (schemaDescription && indent !== 0) {
-      const description = offset + '*' + schemaDescription.replace(/\n\n/g, '\n\n' + offset) + '*';
+      const description = offset + '*' + schemaDescription.replace(/\n/g, '\n' + offset) + '*';
       // put description to the end of the title after the block
       text[0] = text[0].replace(/```$/, '```\n' + description);
     }


### PR DESCRIPTION
### What does this PR do?
wrong new line replacement in schema.description for nested sections

### What issues does this PR fix or reference?
https://app.clickup.com/t/862j2wf8u

### Is it tested? How?
manually