### PR TITLE
fix: anyOf performance and process only subSchemas with mustMatch properties

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -984,7 +984,10 @@ function validate(
 
     if (isDefined(schema.const)) {
       const val = getNodeValue(node);
-      if (!equals(val, schema.const)) {
+      if (
+        !equals(val, schema.const) &&
+        !(callFromAutoComplete && isString(val) && isString(schema.const) && schema.const.startsWith(val))
+      ) {
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
           severity: DiagnosticSeverity.Warning,

--- a/src/languageservice/utils/objects.ts
+++ b/src/languageservice/utils/objects.ts
@@ -62,7 +62,7 @@ export function isNumber(val: unknown): val is number {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function isDefined(val: unknown): val is object {
+export function isDefined(val: unknown): val is object | string | number | boolean {
   return typeof val !== 'undefined';
 }
 

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1880,7 +1880,68 @@ obj:
       expect(result).to.be.empty;
     });
   });
+
   describe('Jigx', () => {
+    describe('Provider anyOf test', () => {
+      it('should choose correct provider1 based on mustMatch properties even the second option has more propertiesValueMatches', async () => {
+        const schema = {
+          anyOf: [
+            {
+              properties: {
+                provider: {
+                  const: 'provider1',
+                },
+                entity: {
+                  type: 'string',
+                },
+                data: {
+                  type: 'object',
+                  additionalProperties: true,
+                  properties: {
+                    b: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['b'],
+                },
+              },
+              required: ['provider', 'entity', 'data'],
+            },
+            {
+              properties: {
+                provider: {
+                  anyOf: [{ const: 'provider2' }, { const: 'provider3' }],
+                },
+                entity: {
+                  enum: ['entity1', 'entity2'],
+                },
+                data: {
+                  type: 'object',
+                  additionalProperties: true,
+                  properties: {
+                    a: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['a'],
+                },
+              },
+              required: ['provider', 'entity', 'data'],
+            },
+          ],
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = `
+provider: provider1
+entity: entity1
+data:
+  a: val
+`;
+        const result = await parseSetup(content);
+        expect(result?.map((r) => r.message)).deep.equals(['Missing property "b".']);
+      });
+    });
+
     it('Expression is valid inline object', async function () {
       const schema = {
         id: 'test://schemas/main',


### PR DESCRIPTION
### What does this PR do?
increase performance
skip alternatives that are not valid
 - it's useless to test alternatives that have different `type`, `provider` 


### What issues does this PR fix or reference?
https://app.clickup.com/t/8684wchv4

### Is it tested? How?

adds test for better choosing between more possible options

it's complicated to test performance without mocking (jest)
 - performance manually for now