### PR TITLE
fix: array completion after colon

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -143,6 +143,20 @@ export class YamlCompletion {
         firstPrefix + arrayIndentCompensation,
         this.indentation + arrayIndentCompensation
       );
+      if (result.items.length === 0) {
+        // try with array symbol
+        result = await this.doCompletionWithModification(
+          result,
+          document,
+          position,
+          isKubernetes,
+          doComplete,
+          Position.create(newPosition.line, newPosition.character + 2),
+          modificationForInvoke + '- ',
+          firstPrefix + arrayIndentCompensation + '- ',
+          this.indentation + arrayIndentCompensation
+        );
+      }
     }
 
     // if no suggestions and if on an empty line then try as an array

--- a/test/autoCompletionExtend.test.ts
+++ b/test/autoCompletionExtend.test.ts
@@ -343,7 +343,7 @@ describe('Auto Completion Tests Extended', () => {
   });
 
   describe('completion of array', () => {
-    it('should suggest when no hypen (-)', async () => {
+    it('should suggest when no hyphen (-)', async () => {
       const schema = {
         type: 'object',
         properties: {
@@ -368,6 +368,23 @@ describe('Auto Completion Tests Extended', () => {
       const content = 'actions:\n  ';
       const completion = await parseSetup(content, content.length);
       assert.equal(completion.items.length, 1);
+    });
+    it('should suggest when no hyphen (-) just after the colon', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          actions: {
+            type: 'array',
+            items: {
+              enum: ['a', 'b', 'c'],
+            },
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'actions:';
+      const completion = await parseSetup(content, content.length);
+      assert.equal(completion.items.length, 3);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
try code-completion for an array when the cursor is just behind the dash `:`

<img width="337" alt="image" src="https://github.com/p-spacek/yaml-language-server/assets/38421337/3f5257e7-97f1-4ce7-9919-105678e15bba">

### What issues does this PR fix or reference?
https://app.clickup.com/t/3yacrwv

### Is it tested? How?
unit test