### PR TITLE
fix: schema loading performance

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -164,6 +164,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     const resolveErrors: string[] = schemaToResolve.errors.slice(0);
     let schema: JSONSchema = schemaToResolve.schema;
     const contextService = this.contextService;
+    const seen: Set<JSONSchema> = new Set();
 
     if (!schema07Validator(schema)) {
       const errs: string[] = [];
@@ -242,7 +243,6 @@ export class YAMLSchemaService extends JSONSchemaService {
       }
 
       const toWalk: JSONSchema[] = [node];
-      const seen: JSONSchema[] = [];
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const openPromises: Promise<any>[] = [];
@@ -278,7 +278,7 @@ export class YAMLSchemaService extends JSONSchemaService {
         }
       };
       const handleRef = (next: JSONSchema): void => {
-        const seenRefs = [];
+        const seenRefs = new Set();
         while (next.$ref) {
           const ref = next.$ref;
           const segments = ref.split('#', 2);
@@ -289,9 +289,9 @@ export class YAMLSchemaService extends JSONSchemaService {
             openPromises.push(resolveExternalLink(next, segments[0], segments[1], parentSchemaURL, parentSchemaDependencies));
             return;
           } else {
-            if (seenRefs.indexOf(ref) === -1) {
+            if (!seenRefs.has(ref)) {
               merge(next, parentSchema, parentSchemaURL, segments[1]); // can set next.$ref again, use seenRefs to avoid circle
-              seenRefs.push(ref);
+              seenRefs.add(ref);
             }
           }
         }
@@ -330,10 +330,10 @@ export class YAMLSchemaService extends JSONSchemaService {
 
       while (toWalk.length) {
         const next = toWalk.pop();
-        if (seen.indexOf(next) >= 0) {
+        if (seen.has(next)) {
           continue;
         }
-        seen.push(next);
+        seen.add(next);
         handleRef(next);
       }
       return Promise.all(openPromises);

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -164,7 +164,6 @@ export class YAMLSchemaService extends JSONSchemaService {
     const resolveErrors: string[] = schemaToResolve.errors.slice(0);
     let schema: JSONSchema = schemaToResolve.schema;
     const contextService = this.contextService;
-    const seen: Set<JSONSchema> = new Set();
 
     if (!schema07Validator(schema)) {
       const errs: string[] = [];
@@ -243,6 +242,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       }
 
       const toWalk: JSONSchema[] = [node];
+      const seen: Set<JSONSchema> = new Set();
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const openPromises: Promise<any>[] = [];


### PR DESCRIPTION
### What does this PR do?
reduce the time to resolve schemas content
fix: replace `Array` with `Set`
performance of checking if the `Set.has` item is better than `Array.indexOf`

### What issues does this PR fix or reference?
https://app.clickup.com/t/8685hgbtr

### Is it tested? How?
manually with +-20 large schemas
loading time from 3.5sec decreased to 1.5sec