### PR TITLE
fix: doNotSuggest for property and value completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -691,6 +691,10 @@ export class YamlCompletion {
       });
     }
     for (const schema of matchingSchemas) {
+      if (schema.schema.doNotSuggest) {
+        continue;
+      }
+
       if (
         ((schema.node.internalNode === node && !matchOriginal) ||
           (schema.node.internalNode === originalNode && !hasColon) ||
@@ -716,7 +720,7 @@ export class YamlCompletion {
               if (Object.prototype.hasOwnProperty.call(schemaProperties, key)) {
                 const propertySchema = schemaProperties[key];
 
-                if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema['doNotSuggest']) {
+                if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema.doNotSuggest) {
                   let identCompensation = '';
                   if (nodeParent && isSeq(nodeParent) && node.items.length <= 1 && !hasOnlyWhitespace) {
                     // because there is a slash '-' to prevent the properties generated to have the correct
@@ -1308,6 +1312,10 @@ export class YamlCompletion {
     isArray?: boolean
   ): void {
     if (typeof schema === 'object') {
+      if (schema.doNotSuggest) {
+        return;
+      }
+
       this.addEnumValueCompletions(schema, separatorAfter, collector, isArray);
       this.addDefaultValueCompletions(schema, separatorAfter, collector);
       this.collectTypes(schema, types);

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -1305,4 +1305,70 @@ test1:
     expect(completion.items[0].insertText).to.be.equal('${1:property}: ');
     expect(completion.items[0].documentation).to.be.equal('Property Description');
   });
+
+  describe('doNotSuggest schema', () => {
+    it('should not autocomplete schema with doNotSuggest - property completion', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          prop1: { type: 'string' },
+        },
+        doNotSuggest: true,
+      };
+      schemaProvider.addSchema(SCHEMA_ID, schema);
+      const content = '';
+      const completion = await parseSetup(content, 0, 1);
+
+      expect(completion.items.length).equal(0);
+    });
+    it('should not autocomplete schema with doNotSuggest - value completion', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          prop1: {
+            anyOf: [
+              {
+                type: 'string',
+                default: 'value_default',
+                doNotSuggest: true,
+              },
+              {
+                type: 'object',
+                defaultSnippets: [
+                  {
+                    label: 'snippet',
+                    body: {
+                      value1: 'value_snippet',
+                    },
+                  },
+                ],
+                doNotSuggest: true,
+              },
+            ],
+          },
+        },
+      };
+      schemaProvider.addSchema(SCHEMA_ID, schema);
+      const content = 'prop1: ';
+      const completion = await parseSetup(content, 0, content.length);
+
+      expect(completion.items.length).equal(0);
+    });
+    it('should autocomplete inside schema in doNotSuggest', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          obj1: {
+            properties: {
+              item1: { type: 'string' },
+            },
+          },
+        },
+        doNotSuggest: true,
+      };
+      schemaProvider.addSchema(SCHEMA_ID, schema);
+      const content = 'obj1:\n | |';
+      const completion = await parseCaret(content);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0].label).equal('item1');
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
RedHat PR: https://github.com/redhat-developer/yaml-language-server/pull/911

exclude doNotSuggest schema from autocompletion
`doNotSuggest` was already there but implemented only for the simple object properties.
This PR uses `doNotSuggest` also for other scenarios: anyOf, values

```json
"anyOf":[
  {
     "$ref": "schema1",
     "doNotSuggest": true
   },
  {
     "$ref": "schema2",
   }
]
```

### Is it tested? How?
adds unit tests