### PR TITLE
feat/quick fix enum const property jigx

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -991,6 +991,7 @@ function validate(
             ),
           source: getSchemaSource(schema, originalSchema),
           schemaUri: getSchemaUri(schema, originalSchema),
+          data: { values: schema.enum },
         });
       }
     }
@@ -1010,6 +1011,7 @@ function validate(
           source: getSchemaSource(schema, originalSchema),
           schemaUri: getSchemaUri(schema, originalSchema),
           problemArgs: [JSON.stringify(schema.const)],
+          data: { values: [schema.const] },
         });
         validationResult.enumValueMatch = false;
       } else {
@@ -1510,6 +1512,7 @@ function validate(
                 length: propertyNode.keyNode.length,
               },
               severity: DiagnosticSeverity.Warning,
+              code: ErrorCode.PropertyExpected,
               message: schema.errorMessage || localize('DisallowedExtraPropWarning', MSG_PROPERTY_NOT_ALLOWED, propertyName),
               source: getSchemaSource(schema, originalSchema),
               schemaUri: getSchemaUri(schema, originalSchema),

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -26,6 +26,7 @@ import { KUBERNETES_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
 import { IProblem } from '../src/languageservice/parser/jsonParser07';
 import { JSONSchema } from '../src/languageservice/jsonSchema';
 import { TestTelemetry } from './utils/testsTypes';
+import { ErrorCode } from 'vscode-json-languageservice';
 
 describe('Validation Tests', () => {
   let languageSettingsSetup: ServiceSetup;
@@ -396,7 +397,8 @@ describe('Validation Tests', () => {
               4,
               DiagnosticSeverity.Error,
               `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
+              `file:///${SCHEMA_ID}`,
+              ErrorCode.PropertyExpected
             )
           );
         })
@@ -1349,6 +1351,7 @@ obj:
           DiagnosticSeverity.Error,
           'yaml-schema: Drone CI configuration file',
           'https://json.schemastore.org/drone',
+          ErrorCode.PropertyExpected,
           {
             properties: [
               'type',

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -40,12 +40,22 @@ export function createDiagnosticWithData(
   severity: DiagnosticSeverity = 1,
   source = 'YAML',
   schemaUri: string | string[],
+  code: string | number = ErrorCode.Undefined,
   data: Record<string, unknown> = {}
 ): Diagnostic {
   if (jigxBranchTest) {
     source = source.replace('yaml-schema: file:///', 'yaml-schema: ');
   }
-  const diagnostic: Diagnostic = createExpectedError(message, startLine, startCharacter, endLine, endCharacter, severity, source);
+  const diagnostic: Diagnostic = createExpectedError(
+    message,
+    startLine,
+    startCharacter,
+    endLine,
+    endCharacter,
+    severity,
+    source,
+    code
+  );
   diagnostic.data = { schemaUri: typeof schemaUri === 'string' ? [schemaUri] : schemaUri, ...data };
   return diagnostic;
 }


### PR DESCRIPTION
### What does this PR do?

copy of https://github.com/redhat-developer/yaml-language-server/pull/911

add quick fix code-action for enums, consts, properties

<img width="225" alt="Screenshot 2023-07-10 at 13 56 00" src="https://github.com/redhat-developer/yaml-language-server/assets/38421337/250e5363-1678-43f9-9ae5-bca6d1e5e3f2">

<img width="216" alt="Screenshot 2023-07-10 at 13 55 16" src="https://github.com/redhat-developer/yaml-language-server/assets/38421337/6fa9b89c-5494-4986-9bdd-b7fa9d52cea5">


### What issues does this PR fix or reference?
no ref


### Is it tested? How?
tests