### PR TITLE
chore: add another test and fix failing tests

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -308,11 +308,11 @@ export class YamlCompletion {
 
     this.arrayPrefixIndentation = '';
     let overwriteRange: Range = null;
+    const isOnlyHyphen = lineContent.match(/^\s*(-)\s*$/);
     if (areOnlySpacesAfterPosition) {
       overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
       const isOnlyWhitespace = lineContent.trim().length === 0;
-      const isOnlyDash = lineContent.match(/^\s*(-)\s*$/);
-      if (node && isScalar(node) && !isOnlyWhitespace && !isOnlyDash) {
+      if (node && isScalar(node) && !isOnlyWhitespace && !isOnlyHyphen) {
         const lineToPosition = lineContent.substring(0, position.character);
         const matches =
           // get indentation of unfinished property (between indent and cursor)
@@ -522,6 +522,12 @@ export class YamlCompletion {
       if (node) {
         if (lineContent.length === 0) {
           node = currentDoc.internalDocument.contents as Node;
+        } else if (isSeq(node) && isOnlyHyphen) {
+          const index = this.findItemAtOffset(node, document, offset);
+          const item = node.items[index];
+          if (isNode(item)) {
+            node = item;
+          }
         } else {
           const parent = currentDoc.getParent(node);
           if (parent) {
@@ -886,19 +892,19 @@ export class YamlCompletion {
                 const propertySchema = schemaProperties[key];
 
                 if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema.doNotSuggest) {
-                  let identCompensation = '';
+                  let indentCompensation = '';
                   if (nodeParent && isSeq(nodeParent) && node.items.length <= 1 && !hasOnlyWhitespace) {
-                    // because there is a slash '-' to prevent the properties generated to have the correct
-                    // indent
-                    const sourceText = textBuffer.getText();
-                    const indexOfSlash = sourceText.lastIndexOf('-', node.range[0] - 1);
-                    if (indexOfSlash >= 0) {
-                      // add one space to compensate the '-'
-                      const overwriteChars = overwriteRange.end.character - overwriteRange.start.character;
-                      identCompensation = ' ' + sourceText.slice(indexOfSlash + 1, node.range[1] - overwriteChars);
+                    // because there is a slash '-' to prevent the properties generated to have the correct indent
+                    const fromLastHyphenToPosition = lineContent.slice(
+                      lineContent.lastIndexOf('-'),
+                      overwriteRange.start.character
+                    );
+                    const hyphenFollowedByEmpty = fromLastHyphenToPosition.match(/-([ \t]*)/);
+                    if (hyphenFollowedByEmpty) {
+                      indentCompensation = ' ' + hyphenFollowedByEmpty[1];
                     }
                   }
-                  identCompensation += this.arrayPrefixIndentation;
+                  indentCompensation += this.arrayPrefixIndentation;
 
                   // if check that current node has last pair with "null" value and key witch match key from schema,
                   // and if schema has array definition it add completion item for array item creation
@@ -929,7 +935,7 @@ export class YamlCompletion {
                       key,
                       propertySchema,
                       separatorAfter,
-                      identCompensation + this.indentation
+                      indentCompensation + this.indentation
                     );
                   }
                   const isNodeNull =
@@ -956,13 +962,13 @@ export class YamlCompletion {
                         key,
                         propertySchema,
                         separatorAfter,
-                        identCompensation + this.indentation
+                        indentCompensation + this.indentation
                       ),
                       insertTextFormat: InsertTextFormat.Snippet,
                       documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || '',
                       parent: {
                         schema: schema.schema,
-                        indent: identCompensation,
+                        indent: indentCompensation,
                       },
                     });
                   }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -308,7 +308,7 @@ export class YamlCompletion {
 
     this.arrayPrefixIndentation = '';
     let overwriteRange: Range = null;
-    const isOnlyHyphen = lineContent.match(/^\s*(-)\s*$/);
+    const isOnlyHyphen = lineContent.match(/^\s*(-)\s*($|#)/);
     if (areOnlySpacesAfterPosition) {
       overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
       const isOnlyWhitespace = lineContent.trim().length === 0;

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -902,6 +902,30 @@ objB:
         })
       );
     });
+    it('indent compensation for partial key with trailing spaces', async () => {
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          array: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                obj1: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'array:\n - na   ';
+      const completion = await parseSetup(content, 1, 5);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0].insertText).eql('obj1:\n    ');
+    });
 
     describe('partial value with trailing spaces', () => {
       it('partial value with trailing spaces', async () => {
@@ -1197,6 +1221,44 @@ objB:
 
       expect(result.items.length).to.be.equal(1);
       expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
+    });
+
+    describe('array item with existing property', () => {
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          array1: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                objA: {
+                  type: 'object',
+                },
+                propB: {
+                  const: 'test',
+                },
+              },
+            },
+          },
+        },
+      };
+      it('should get extra space compensation for the 1st prop in array object item', async () => {
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'array1:\n  - \n    propB: test';
+        const result = await parseSetup(content, 1, 4); // after `- `
+
+        expect(result.items.length).to.be.equal(1);
+        expect(result.items[0].insertText).to.be.equal('objA:\n    ');
+      });
+      it('should get extra space compensation for the 1st prop in array object item - extra spaces', async () => {
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'array1:\n  -     \n    propB: test';
+        const result = await parseSetup(content, 1, 4); // after `- `
+
+        expect(result.items.length).to.be.equal(1);
+        expect(result.items[0].insertText).to.be.equal('objA:\n    ');
+      });
     });
   }); //'extra space after cursor'
 

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -920,8 +920,8 @@ objB:
         },
       };
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'array:\n - na   ';
-      const completion = await parseSetup(content, 1, 5);
+      const content = 'array:\n - na| |  ';
+      const completion = await parseCaret(content);
 
       expect(completion.items.length).equal(1);
       expect(completion.items[0].insertText).eql('obj1:\n    ');
@@ -1245,16 +1245,25 @@ objB:
       };
       it('should get extra space compensation for the 1st prop in array object item', async () => {
         languageService.addSchema(SCHEMA_ID, schema);
-        const content = 'array1:\n  - \n    propB: test';
-        const result = await parseSetup(content, 1, 4); // after `- `
+        const content = 'array1:\n  - |\n|    propB: test';
+        const result = await parseCaret(content);
 
         expect(result.items.length).to.be.equal(1);
         expect(result.items[0].insertText).to.be.equal('objA:\n    ');
       });
       it('should get extra space compensation for the 1st prop in array object item - extra spaces', async () => {
         languageService.addSchema(SCHEMA_ID, schema);
-        const content = 'array1:\n  -     \n    propB: test';
-        const result = await parseSetup(content, 1, 4); // after `- `
+        const content = 'array1:\n  - | |   \n    propB: test';
+        const result = await parseCaret(content);
+
+        expect(result.items.length).to.be.equal(1);
+        expect(result.items[0].insertText).to.be.equal('objA:\n    ');
+      });
+      // previous PR doesn't fix this
+      it.skip('should get extra space compensation for the 1st prop in array object item - extra lines', async () => {
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'array1:\n  - \n    |\n|    propB: test';
+        const result = await parseCaret(content);
 
         expect(result.items.length).to.be.equal(1);
         expect(result.items[0].insertText).to.be.equal('objA:\n    ');

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -919,8 +919,8 @@ objB:
           },
         },
       };
-      languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'array:\n - na| |  ';
+      schemaProvider.addSchema(SCHEMA_ID, schema);
+      const content = 'array:\n  - obj| |  ';
       const completion = await parseCaret(content);
 
       expect(completion.items.length).equal(1);
@@ -1146,6 +1146,41 @@ objB:
       expect(result.items.length).to.be.equal(1);
       expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
     });
+
+    it('array completion - should suggest correct indent when extra spaces after cursor followed by with different array item', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          test: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                objA: {
+                  type: 'object',
+                  required: ['itemA'],
+                  properties: {
+                    itemA: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const content = `
+test:
+  - | |    
+  - objA:
+      itemA: test`;
+      const result = await parseCaret(content);
+
+      expect(result.items.length).to.be.equal(1);
+      expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
+    });
+
     it('array of arrays completion - should suggest correct indent when extra spaces after cursor', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
@@ -1244,7 +1279,7 @@ objB:
         },
       };
       it('should get extra space compensation for the 1st prop in array object item', async () => {
-        languageService.addSchema(SCHEMA_ID, schema);
+        schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = 'array1:\n  - |\n|    propB: test';
         const result = await parseCaret(content);
 
@@ -1252,17 +1287,8 @@ objB:
         expect(result.items[0].insertText).to.be.equal('objA:\n    ');
       });
       it('should get extra space compensation for the 1st prop in array object item - extra spaces', async () => {
-        languageService.addSchema(SCHEMA_ID, schema);
+        schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = 'array1:\n  - | |   \n    propB: test';
-        const result = await parseCaret(content);
-
-        expect(result.items.length).to.be.equal(1);
-        expect(result.items[0].insertText).to.be.equal('objA:\n    ');
-      });
-      // previous PR doesn't fix this
-      it.skip('should get extra space compensation for the 1st prop in array object item - extra lines', async () => {
-        languageService.addSchema(SCHEMA_ID, schema);
-        const content = 'array1:\n  - \n    |\n|    propB: test';
         const result = await parseCaret(content);
 
         expect(result.items.length).to.be.equal(1);

--- a/test/yaml-documents.test.ts
+++ b/test/yaml-documents.test.ts
@@ -212,6 +212,18 @@ objB:
     });
 
     describe('Array', () => {
+      // Problem in `getNodeFromPosition` function. This method doesn't give proper results for arrays
+      // for example, this yaml return nodes:
+      // foo:
+      // - # foo object is returned (should be foo[0])
+      //   # foo object is returned (should be foo[0])
+      //   item1: aaaf
+      //   # foo[0] object is returned (OK)
+      // - # foo object is returned (should be foo[1])
+      //   # foo[!!0!!] object is returned (should be foo[1])
+      //   item2: bbb
+      //   # foo[1] object is returned (OK)
+
       it('Find closes node: array', () => {
         const doc = setupTextDocument('foo:\n  - bar: aaa\n  ');
         const yamlDoc = documents.getYamlDocument(doc);

--- a/test/yaml-documents.test.ts
+++ b/test/yaml-documents.test.ts
@@ -211,16 +211,77 @@ objB:
       expect(((result as YAMLMap).items[0].key as Scalar).value).eqls('bar');
     });
 
-    it('Find closes node: array', () => {
-      const doc = setupTextDocument('foo:\n  - bar: aaa\n  ');
-      const yamlDoc = documents.getYamlDocument(doc);
-      const textBuffer = new TextBuffer(doc);
+    describe('Array', () => {
+      it('Find closes node: array', () => {
+        const doc = setupTextDocument('foo:\n  - bar: aaa\n  ');
+        const yamlDoc = documents.getYamlDocument(doc);
+        const textBuffer = new TextBuffer(doc);
 
-      const result = yamlDoc.documents[0].findClosestNode(20, textBuffer);
+        const result = yamlDoc.documents[0].findClosestNode(20, textBuffer);
 
-      expect(result).is.not.undefined;
-      expect(isSeq(result)).is.true;
-      expect((((result as YAMLSeq).items[0] as YAMLMap).items[0].key as Scalar).value).eqls('bar');
+        expect(result).is.not.undefined;
+        expect(isSeq(result)).is.true;
+        expect((((result as YAMLSeq).items[0] as YAMLMap).items[0].key as Scalar).value).eqls('bar');
+      });
+      it.skip('Find first array item node', () => {
+        const doc = setupTextDocument(`foo:
+  - 
+    item1: aaa
+`);
+        const yamlDoc = documents.getYamlDocument(doc);
+        const textBuffer = new TextBuffer(doc);
+
+        const result = yamlDoc.documents[0].findClosestNode(9, textBuffer);
+
+        expect(result).is.not.undefined;
+        expect(isMap(result)).is.true;
+        expect(((result as YAMLMap).items[0].key as Scalar).value).eqls('item1');
+      });
+      it.skip('Find first array item node - extra indent', () => {
+        const doc = setupTextDocument(`foo:
+  - 
+    
+    item1: aaa
+`);
+        const yamlDoc = documents.getYamlDocument(doc);
+        const textBuffer = new TextBuffer(doc);
+
+        const result = yamlDoc.documents[0].findClosestNode(9, textBuffer);
+
+        expect(result).is.not.undefined;
+        expect(isMap(result)).is.true;
+        expect(((result as YAMLMap).items[0].key as Scalar).value).eqls('item1');
+      });
+
+      it.skip('Find second array item node', () => {
+        const doc = setupTextDocument(`foo:
+  - item1: aaa
+  - 
+    item2: bbb`);
+        const yamlDoc = documents.getYamlDocument(doc);
+        const textBuffer = new TextBuffer(doc);
+
+        const result = yamlDoc.documents[0].findClosestNode(24, textBuffer);
+
+        expect(result).is.not.undefined;
+        expect(isMap(result)).is.true;
+        expect(((result as YAMLMap).items[0].key as Scalar).value).eqls('item2');
+      });
+      it.skip('Find second array item node: - extra indent', () => {
+        const doc = setupTextDocument(`foo:
+  - item1: aaa
+  -
+    
+    item2: bbb`);
+        const yamlDoc = documents.getYamlDocument(doc);
+        const textBuffer = new TextBuffer(doc);
+
+        const result = yamlDoc.documents[0].findClosestNode(28, textBuffer);
+
+        expect(result).is.not.undefined;
+        expect(isMap(result)).is.true;
+        expect(((result as YAMLMap).items[0].key as Scalar).value).eqls('item2');
+      });
     });
 
     it('Find closes node: root map', () => {


### PR DESCRIPTION
### What does this PR do?
original PR: https://github.com/redhat-developer/yaml-language-server/pull/882
there is still open discussion if this PR is correct.
I think it is in terms of current implementation. To fix it properly the `findClosestNode` has to be fixed - see the skipped tests in this PR...

fix autocompletion when the position is on the same line with the hyphen followed by other props

there are two problems:
1) intellisense doesn't work correctly for the first item when there is another prop in the array item
<img width="318" alt="Screenshot 2023-05-17 at 09 37 56" src="https://github.com/redhat-developer/yaml-language-server/assets/38421337/11112f49-f000-4bce-8333-e54cf33ed6b2">
<img width="241" alt="Screenshot 2023-05-17 at 09 37 24" src="https://github.com/redhat-developer/yaml-language-server/assets/38421337/efc798bf-74da-4adb-95b9-d9930a621efe">

https://github.com/redhat-developer/yaml-language-server/assets/38421337/97997ad7-06dc-44f1-89ff-4581859f7ee5

2) the compensation of the indentation is not correct for the first item after the hyphen

https://github.com/redhat-developer/yaml-language-server/assets/38421337/46f4a5fe-a450-45b6-bc6e-77f5e982d8a4

after fix of the 1st problem, the 2nd problem looks like this 

https://github.com/redhat-developer/yaml-language-server/assets/38421337/2f7b6430-b4ac-49de-93e3-98281e9f7911


after fix:

https://github.com/redhat-developer/yaml-language-server/assets/38421337/f04e5ea0-6eda-4586-9464-d4fa41aaef5f

UPDATE: 
3) this PR also fixes this issue:

https://github.com/redhat-developer/yaml-language-server/assets/38421337/c29c9e7c-fa8a-4dfb-9978-6ecc616c2fb6




### What issues does this PR fix or reference?
no reference

### Is it tested? How?
add unit tests