### PR TITLE
Fix: array item with existing property jigx

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -326,6 +326,8 @@ export class YamlCompletion {
             Position.create(position.line, lineContent.length)
           );
         }
+      } else if (node && isScalar(node) && node.value === null && currentWord === '-') {
+        this.arrayPrefixIndentation = ' ';
       }
     } else if (node && isScalar(node) && node.value === 'null') {
       const nodeStartPos = document.positionAt(node.range[0]);

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -1181,6 +1181,42 @@ test:
       expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
     });
 
+    it('array completion - should suggest correct indent when cursor is just after hyphen with trailing spaces', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          test: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                objA: {
+                  type: 'object',
+                  required: ['itemA'],
+                  properties: {
+                    itemA: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const content = `
+test:
+  -| |    
+`;
+      const result = await parseCaret(content);
+
+      expect(result.items.length).to.be.equal(1);
+      expect(result.items[0].textEdit).to.deep.equal({
+        newText: ' objA:\n    itemA: ',
+        // range should contains all the trailing spaces
+        range: Range.create(2, 3, 2, 9),
+      });
+    });
     it('array of arrays completion - should suggest correct indent when extra spaces after cursor', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',


### PR DESCRIPTION
### What does this PR do?
correct indent when the cursor is just after the hyphen with trailing spaces

https://github.com/redhat-developer/yaml-language-server/assets/38421337/7c8cc524-9bc3-43dc-aedb-846a0e40d70e

### What issues does this PR fix or reference?
https://app.clickup.com/t/3yacry6?comment=90110028762860


### Is it tested? How?
unit test