### PR TITLE
feat: chain single properties

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -69,6 +69,8 @@ interface InsertText {
   insertIndex: number;
 }
 
+export const expressionSchemaName = 'expression';
+
 export class YamlCompletion {
   private customTags: string[];
   private completionEnabled = true;
@@ -943,7 +945,9 @@ export class YamlCompletion {
                   const isNodeNull =
                     (isScalar(originalNode) && originalNode.value === null) ||
                     (isMap(originalNode) && originalNode.items.length === 0);
-                  const existsParentCompletion = schema.schema.required?.length > 0;
+                  // jigx custom - exclude parent skeleton for expression completion, required prop made troubles
+                  const existsParentCompletion = schema.schema.required?.length > 0 && doc.uri !== expressionSchemaName;
+                  // end jigx custom
                   if (!this.parentSkeletonSelectedFirst || !isNodeNull || !existsParentCompletion) {
                     collector.add(
                       {
@@ -957,7 +961,7 @@ export class YamlCompletion {
                     );
                   }
                   // if the prop is required add it also to parent suggestion
-                  if (schema.schema.required?.includes(key)) {
+                  if (existsParentCompletion && schema.schema.required?.includes(key)) {
                     collector.add({
                       label: key,
                       insertText: this.getInsertTextForProperty(


### PR DESCRIPTION
### What does this PR do?

remove parent skeleton functionality from intellisense when the file is 'expression'
it means that skeleton can't be suggested when there is code completion for expression `@ctx.`

### What issues does this PR fix or reference?
related to #8685z833f
https://app.clickup.com/t/8685z833f

### Is it tested? How?
added simple test
more tests in the builder
