### PR TITLE
fix: allows pattern error in mustMatchProperty functionality

### DIFF
--- a/src/languageserver/handlers/requestHandlers.ts
+++ b/src/languageserver/handlers/requestHandlers.ts
@@ -52,6 +52,9 @@ export class RequestHandlers {
      */
     this.connection.onRequest(RevalidateRequest.type, async (uri: string) => {
       const document = this.yamlSettings.documents.get(uri);
+      if (!document) {
+        console.log('Revalidate: No document found for uri: ' + uri);
+      }
       await this.validationHandler.validate(document);
     });
 

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1946,6 +1946,35 @@ data:
         const result = await parseSetup(content);
         expect(result?.map((r) => r.message)).deep.equals(['Missing property "b".']);
       });
+
+      it('should allow provider with invalid value and propagate inner pattern error', async () => {
+        const schema = {
+          anyOf: [
+            {
+              properties: {
+                provider: {
+                  const: 'provider1',
+                  pattern: '^$',
+                  patternErrorMessage: 'Try to avoid provider1',
+                },
+              },
+              required: ['provider'],
+            },
+            {
+              properties: {
+                provider: {
+                  const: 'provider2',
+                },
+              },
+              required: ['provider'],
+            },
+          ],
+        };
+        schemaProvider.addSchema(SCHEMA_ID, schema);
+        const content = 'provider: provider1';
+        const result = await parseSetup(content);
+        expect(result?.map((r) => r.message)).deep.equals(['Try to avoid provider1']);
+      });
     });
 
     it('Expression is valid inline object', async function () {


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix or reference?
https://app.clickup.com/t/8686wjyzg
If pattern validation is used for mustMatch property (e.g. provider), it should take this alternative if the const match even if the validation pattern is not valid


### Is it tested? How?
unit-test
