### PR TITLE
fix: hover-duplicities

### DIFF
--- a/test/hoverDetail.test.ts
+++ b/test/hoverDetail.test.ts
@@ -3,12 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
+import * as chai from 'chai';
 import * as path from 'path';
-import { Hover, MarkupContent } from 'vscode-languageserver';
+import { MarkupContent } from 'vscode-languageserver';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import { YamlHoverDetailResult } from '../src/languageservice/services/yamlHoverDetail';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
 import { SCHEMA_ID, TestCustomSchemaProvider, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+const expect = chai.expect;
 
 describe('Hover Tests Detail', () => {
   let languageSettingsSetup: ServiceSetup;
@@ -35,14 +38,14 @@ describe('Hover Tests Detail', () => {
     schemaProvider.deleteSchema(SCHEMA_ID);
   });
 
-  function parseSetup(content: string, position, customSchema?: string): Promise<Hover> {
+  function parseSetup(content: string, position, customSchema?: string): Promise<YamlHoverDetailResult> {
     const testTextDocument = setupSchemaIDTextDocument(content, customSchema);
     yamlSettings.documents = new TextDocumentTestManager();
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
     return languageHandler.hoverHandler({
       position: testTextDocument.positionAt(position),
       textDocument: testTextDocument,
-    });
+    }) as Promise<YamlHoverDetailResult>;
   }
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const inlineObjectSchema = require(path.join(__dirname, './fixtures/testInlineObject.json'));
@@ -199,6 +202,147 @@ test: \`const1\` | object | Expression | string | obj1
       const result = await parseSetup(content, 1, SCHEMA_ID);
 
       assert.strictEqual((result.contents as MarkupContent).value, '## `$sum()');
+    });
+  });
+  describe('Schema distinct', async () => {
+    it('Should not remove slightly different schema ', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              prop1: {
+                type: 'string',
+                description: 'description1',
+                title: 'title1',
+                const: 'const1',
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              prop1: {
+                type: 'string',
+                description: 'description2',
+                title: 'title2',
+                const: 'const2',
+              },
+            },
+          },
+        ],
+      });
+      const content = 'prop1: test';
+      const result = await parseSetup(content, 2, SCHEMA_ID);
+      const value = (result.contents as MarkupContent).value;
+      assert.equal(result.schemas.length, 2, 'should not remove schema');
+      expect(value).includes("title1 'const1' | title2 'const2'", 'should have both titles and const');
+      expect(value).includes('description1');
+      expect(value).includes('description2');
+    });
+    it('Should remove schema duplicities for equal hover result', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              scripts: {
+                type: 'string',
+                description: 'description',
+                title: 'title',
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              scripts: {
+                type: 'string',
+                description: 'description',
+                title: 'title',
+              },
+            },
+          },
+        ],
+      });
+      const content = 'scripts: test';
+      const result = await parseSetup(content, 2, SCHEMA_ID);
+      const value = (result.contents as MarkupContent).value;
+      assert.equal(result.schemas.length, 1, 'should have only single schema');
+      assert.equal(
+        value.split('\n').filter((l) => l.includes('description')).length,
+        1,
+        'should have only single description, received:\n' + value
+      );
+    });
+    it('Should remove schema duplicities from $ref', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        definitions: {
+          reusableType: {
+            type: 'object',
+            properties: {
+              prop1: {
+                type: 'string',
+                description: 'description',
+              },
+            },
+            title: 'title',
+          },
+        },
+        anyOf: [
+          {
+            $ref: '#/definitions/reusableType',
+          },
+          {
+            $ref: '#/definitions/reusableType',
+          },
+        ],
+      });
+      const content = 'prop1: test';
+      const result = await parseSetup(content, 2, SCHEMA_ID);
+      const value = (result.contents as MarkupContent).value;
+      assert.equal(result.schemas.length, 1, 'should have only single schema');
+      assert.equal(
+        value.split('\n').filter((l) => l.includes('description')).length,
+        1,
+        'should have only single description, received:\n' + value
+      );
+    });
+
+    it('Should remove schema duplicities from $ref $ref', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        definitions: {
+          reusableType2: {
+            type: 'object',
+            title: 'title',
+          },
+          reusableType: {
+            type: 'object',
+            properties: {
+              prop1: {
+                $ref: '#/definitions/reusableType2',
+              },
+            },
+          },
+        },
+        anyOf: [
+          {
+            $ref: '#/definitions/reusableType',
+          },
+          {
+            $ref: '#/definitions/reusableType',
+          },
+        ],
+      });
+      const content = 'prop1: test';
+      const result = await parseSetup(content, 2, SCHEMA_ID);
+      const value = (result.contents as MarkupContent).value;
+      assert.equal(result.schemas.length, 1, 'should have only single schema');
+      assert.equal(
+        value.split('\n').filter((l) => l.includes('title')).length,
+        1,
+        'should have only single reusableType, received:\n' + value
+      );
     });
   });
 });

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1328,7 +1328,7 @@ obj:
           4,
           18,
           DiagnosticSeverity.Error,
-          'yaml-schema: Package',
+          'yaml-schema: Composer Package',
           'https://raw.githubusercontent.com/composer/composer/master/res/composer-schema.json'
         )
       );


### PR DESCRIPTION
### What does this PR do?

Remove Hover duplicities

1) added a distinct mechanism to schemas for hover, so it will reduce the duplicities

2) added also const  value to the title, so it could explain why the item is listed (it will help with options with the same titles)

alternative is to rename the titles in the schema

but this solution is generic for every const property


3) spread enum type:


### What issues does this PR fix or reference?
main task: https://app.clickup.com/t/868aa9ca4


### Is it tested? How?
tests
