### PR TITLE
Fix: improve any of mustMatch 2 for onedrive data

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -787,12 +787,6 @@ function validate(
         if (!mustMatchYamlProp) {
           continue;
         }
-        // if there will be problem with providers with expression, we can exclude it from this optimization
-        // const mustMatchYamlPropValue = mustMatchYamlProp.valueNode.value;
-        // // value is expression, we can't prioritize or exclude schemas based on this value
-        // if (isExpressionStr(mustMatchYamlPropValue)) {
-        //   continue;
-        // }
 
         // take only subSchemas that have the same mustMatch property in yaml and in schema
         alternativesFiltered = alternatives.filter((subSchemaRef) => {
@@ -810,29 +804,16 @@ function validate(
           if (
             !subValidationResult.hasProblems() ||
             // allows some of the other errors like: patterns validations
-            subValidationResult.enumValueMatch //||
-            // a little bit hack that I wasn't able to solve it in official YLS
-            // problem: some schemas look like this: `provider: { anyOf: [{enum: ['pr1', 'pr2']}, {type: 'string', title: 'expression'}] }`
-            //          and with yaml value `provider: =expression`
-            //          when it's invoked from code-completion both options are merged together as a possible option
-            //             note: if the anyOf order will be opposite, then the first one will be selected as the best match
-            //          but they are merged together also with problems, so even if one of the sub-schema has a problem, the second one can be ok
-            // solution: check if there are more possible schemas and check if there is only single problem
-            // (subMatchingSchemas.schemas.length > 1 && subValidationResult.problems.length === 1)
+            subValidationResult.enumValueMatch
+            // note that there was a special hack for type: `provider: { anyOf: [{enum: ['pr1', 'pr2']}, {type: 'string', title: 'expression'}] }`
+            // seems that we don't need it anymore, caused more troubles
+            // check previous commits for more details
           ) {
             // we have enum/const match on mustMatch prop
             // so we want to use this schema forcely in genericComparison mechanism
             if (subValidationResult.enumValueMatch && subValidationResult.enumValues?.length) {
               mustMatchSchemas.push(subSchema);
             }
-            // it matches some enum but not the current one, so it's not correct schemas
-            // if (
-            //   !subValidationResult.enumValueMatch && // don't match enum
-            //   subValidationResult.enumValues.length && // but has enum or const in schema
-            //   !subValidationResult.enumValues.includes(mustMatchYamlPropValue) // if it's not in schema.enum, then it's not correct schema
-            // ) {
-            //   return false;
-            // }
             return true;
           }
           if (!validationData[mustMatch]) {


### PR DESCRIPTION
### What does this PR do?
fix a specific issue when the generic option can win because the schema was wrongly added to mustMatchSchema.
 - 1st problem: problem with this hack `provider: { anyOf: [{enum: ['pr1', 'pr2']}, {type: 'string', title: 'expression'}] }`
   - was there because of a complicated list schema
 - 2nd problem: primaryValueMatches, propertiesMatches weren't updated with a better match


### What issues does this PR fix or reference?
https://app.clickup.com/t/868anvnb4


### Is it tested? How?
tests
