### PR TITLE
feat: add expected properties to diagnostic message

### DIFF
--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "Array hat zu viele Elemente. Erwartet: {0} oder weniger.",
   "uniqueItemsWarning": "Array enthält doppelte Elemente.",
   "DisallowedExtraPropWarning": "Eigenschaft {0} ist nicht erlaubt.",
+  "DisallowedExtraPropWarningWithExpected": "Eigenschaft {0} ist nicht erlaubt. Erwartet: {1}.",
   "MaxPropWarning": "Objekt hat mehr Eigenschaften als das Limit von {0}.",
   "MinPropWarning": "Objekt hat weniger Eigenschaften als die erforderliche Anzahl von {0}.",
   "RequiredDependentPropWarning": "Objekt fehlt die Eigenschaft {0}, die von Eigenschaft {1} benötigt wird.",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "Le tableau contient trop d'éléments. On attend {0} ou moins.",
   "uniqueItemsWarning": "Le tableau contient des éléments en double.",
   "DisallowedExtraPropWarning": "La propriété {0} n'est pas autorisée.",
+  "DisallowedExtraPropWarningWithExpected": "La propriété {0} n'est pas autorisée. Attendu: {1}.",
   "MaxPropWarning": "L'objet a plus de propriétés que la limite de {0}.",
   "MinPropWarning": "L'objet a moins de propriétés que le nombre requis de {0}",
   "RequiredDependentPropWarning": "L'objet ne possède pas la propriété {0} requise par la propriété {1}.",

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "配列の項目数が多すぎます。{0} 項目以下にしてください。",
   "uniqueItemsWarning": "配列に重複する項目があります。",
   "DisallowedExtraPropWarning": "プロパティ {0} は許可されていません。",
+  "DisallowedExtraPropWarningWithExpected": "プロパティ {0} は許可されていません。期待される値: {1}。",
   "MaxPropWarning": "オブジェクトのプロパティ数が制限値 {0} を超えています。",
   "MinPropWarning": "オブジェクトのプロパティ数が必要数 {0} に満たないです。",
   "RequiredDependentPropWarning": "プロパティ {1} によって必要とされるプロパティ {0} が存在しません。",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "Array has too many items. Expected {0} or fewer.",
   "uniqueItemsWarning": "Array has duplicate items.",
   "DisallowedExtraPropWarning": "Property {0} is not allowed.",
+  "DisallowedExtraPropWarningWithExpected": "Property {0} is not allowed. Expected: {1}.",
   "MaxPropWarning": "Object has more properties than limit of {0}.",
   "MinPropWarning": "Object has fewer properties than the required number of {0}",
   "RequiredDependentPropWarning": "Object is missing property {0} required by property {1}.",
@@ -52,5 +53,5 @@
   "flowStyleMapForbidden": "Flow style mapping is forbidden",
   "flowStyleSeqForbidden": "Flow style sequence is forbidden",
   "unUsedAnchor": "Unused anchor \"{0}\"",
-  "unUsedAlias": "Unresolved alias \"{0}\""  
+  "unUsedAlias": "Unresolved alias \"{0}\""
 }

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "배열 항목 수가 너무 많습니다. 최대 {0}개 허용됩니다.",
   "uniqueItemsWarning": "배열에 중복된 항목이 있습니다.",
   "DisallowedExtraPropWarning": "속성 {0}은(는) 허용되지 않습니다.",
+  "DisallowedExtraPropWarningWithExpected": "속성 {0}은(는) 허용되지 않습니다. 예상: {1}.",
   "MaxPropWarning": "객체에 허용된 속성 수 {0}을 초과했습니다.",
   "MinPropWarning": "객체에 필요한 최소 속성 수 {0}보다 적습니다.",
   "RequiredDependentPropWarning": "속성 {1}에 필요한 속성 {0}이 누락되었습니다.",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "数组项数过多。应为 {0} 项或更少。",
   "uniqueItemsWarning": "数组中包含重复项。",
   "DisallowedExtraPropWarning": "属性 {0} 不被允许。",
+  "DisallowedExtraPropWarningWithExpected": "属性 {0} 不被允许。预期：{1}。",
   "MaxPropWarning": "对象的属性数超过了限制 {0}。",
   "MinPropWarning": "对象的属性数少于所需数量 {0}。",
   "RequiredDependentPropWarning": "属性 {1} 依赖的属性 {0} 缺失。",

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -33,6 +33,7 @@
   "maxItemsWarning": "陣列項目數太多。應為 {0} 項或更少。",
   "uniqueItemsWarning": "陣列中有重複項目。",
   "DisallowedExtraPropWarning": "不允許的屬性 {0}。",
+  "DisallowedExtraPropWarningWithExpected": "不允許的屬性 {0}。預期：{1}。",
   "MaxPropWarning": "物件的屬性數量超過限制 {0}。",
   "MinPropWarning": "物件的屬性數量少於所需的 {0}。",
   "RequiredDependentPropWarning": "缺少由屬性 {1} 所需的屬性 {0}。",

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1370,7 +1370,8 @@ function validate(
               }
               return true;
             })
-            .map(([key]) => key);
+            .map(([key]) => key)
+            .sort();
 
         for (const propertyName of unprocessedProperties) {
           const child = seenKeys[propertyName];
@@ -1391,7 +1392,10 @@ function validate(
               },
               severity: DiagnosticSeverity.Warning,
               code: ErrorCode.PropertyExpected,
-              message: schema.errorMessage || l10n.t('DisallowedExtraPropWarning', propertyName),
+              message:
+                schema.errorMessage || possibleProperties?.length
+                  ? l10n.t('DisallowedExtraPropWarningWithExpected', propertyName, possibleProperties.join(' | '))
+                  : l10n.t('DisallowedExtraPropWarning', propertyName),
               source: getSchemaSource(schema, originalSchema),
               schemaUri: getSchemaUri(schema, originalSchema),
             };

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -12,7 +12,6 @@ import {
   IncludeWithoutValueError,
   BlockMappingEntryError,
   DuplicateKeyError,
-  propertyIsNotAllowed,
   MissingRequiredPropWarning,
 } from './utils/errorMessages';
 import * as assert from 'assert';
@@ -28,7 +27,7 @@ import { JSONSchema } from '../src/languageservice/jsonSchema';
 import { TestTelemetry } from './utils/testsTypes';
 import { ErrorCode } from 'vscode-json-languageservice';
 
-describe('Validation Tests', () => {
+describe.only('Validation Tests', () => {
   let languageSettingsSetup: ServiceSetup;
   let validationHandler: ValidationHandler;
   let languageService: LanguageService;
@@ -1342,7 +1341,7 @@ obj:
       const result = await parseSetup(content, 'file://~/Desktop/vscode-yaml/.drone.yml');
       expect(result[5]).deep.equal(
         createDiagnosticWithData(
-          propertyIsNotAllowed('apiVersion'),
+          'Property apiVersion is not allowed. Expected: clone | concurrency | depends_on | environment | image_pull_secrets | name | node | platform | services | steps | trigger | type | volumes | workspace.',
           1,
           6,
           1,
@@ -1353,20 +1352,20 @@ obj:
           ErrorCode.PropertyExpected,
           {
             properties: [
-              'type',
-              'environment',
-              'steps',
-              'volumes',
-              'services',
-              'image_pull_secrets',
-              'node',
-              'concurrency',
-              'name',
-              'platform',
-              'workspace',
               'clone',
-              'trigger',
+              'concurrency',
               'depends_on',
+              'environment',
+              'image_pull_secrets',
+              'name',
+              'node',
+              'platform',
+              'services',
+              'steps',
+              'trigger',
+              'type',
+              'volumes',
+              'workspace',
             ],
           }
         )
@@ -1690,7 +1689,7 @@ obj:
         const content = `prop2: you should not be there 'prop2'`;
         const result = await parseSetup(content);
         expect(result.length).to.eq(1);
-        expect(result[0].message).to.eq('Property prop2 is not allowed.');
+        expect(result[0].message).to.eq('Property prop2 is not allowed. Expected: prop1.');
         expect((result[0].data as { properties: unknown })?.properties).to.deep.eq(['prop1']);
       });
 
@@ -1716,7 +1715,7 @@ obj:
           }))
         ).to.deep.eq([
           {
-            message: 'Property propX is not allowed.',
+            message: 'Property propX is not allowed. Expected: prop2.',
             properties: ['prop2'],
           },
         ]);
@@ -1756,7 +1755,7 @@ obj:
           }))
         ).to.deep.eq([
           {
-            message: 'Property propX is not allowed.',
+            message: 'Property propX is not allowed. Expected: prop0.',
             properties: ['prop0'],
           },
         ]);

--- a/test/utils/errorMessages.ts
+++ b/test/utils/errorMessages.ts
@@ -19,10 +19,6 @@ export const TypeMismatchWarning = 'Incorrect type. Expected "{0}".';
 export const MissingRequiredPropWarning = 'Missing property "{0}".';
 export const ConstWarning = 'Value must be {0}.';
 
-export function propertyIsNotAllowed(name: string): string {
-  return `Property ${name} is not allowed.`;
-}
-
 /**
  * Parse errors
  */


### PR DESCRIPTION
### What does this PR do?
Add expected properties to the diagnostic message

<img width="499" height="117" alt="image" src="https://github.com/user-attachments/assets/95ab5a8b-de25-48c9-ad88-db1d6acebd76" />

The reason for displaying property information is AI agents. AI chat tools like Copilot or Claude can identify issues during the generation of YAML and the validation process and fix generated issues in the next iteration.

Note that a similar implementation already has enums.
<img width="499" height="55" alt="image" src="https://github.com/user-attachments/assets/853ad7e2-a42a-4c97-afc9-0bdd59826477" />


Note that it can't see the 'data' property (some extra information is already there, but not accessible by AI).

### What issues does this PR fix or reference?


### Is it tested? How?
modified existing tests